### PR TITLE
Declare OneWire dependency

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,6 +15,14 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/DS18B20"
   },
+  "dependencies":
+  [
+    {
+      "owner": "paulstoffregen",
+      "name": "OneWire",
+      "version": "^2.3.5"
+    }
+  ],
   "version": "0.1.10",
   "license": "MIT",
   "frameworks": "arduino",


### PR DESCRIPTION
This library depends on OneWire.h

https://github.com/RobTillaart/DS18B20_RT/blob/957753e2cb4f2d697d4f3a4ec3cb8f51c8fca04f/DS18B20.h#L23

but doesn't declare that dependency in the `library.json` per [the documentation](https://docs.platformio.org/en/latest/librarymanager/config.html#dependencies).

This leads to people using PlatformIO possibly getting a compiler error because the dependency is not automatically downloaded.

This PR fixes that, so that an install..

```
>pio lib -g install https://github.com/maxgerhardt/DS18B20_RT/archive/refs/heads/master.zip
Library Storage: C:\Users\Max\.platformio\lib
Library Manager: Installing https://github.com/maxgerhardt/DS18B20_RT/archive/refs/heads/master.zip
Downloading...
Library Manager: DS18B20 @ 0.1.10 has been installed!
Library Manager: Installing dependencies...
Library Manager: Installing paulstoffregen/OneWire @ ^2.3.5
Library Manager: OneWire @ 2.3.5 has been installed!
```
auto-installs OneWire too.

The `library.properties` remain untouched.